### PR TITLE
New QoL Settings removing ~14K false positives

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,7 +6,6 @@
 		"Lua.workspace.ignoreDir": [ 
 			"lua_help.script"
 		],
-	    "Lua.workspace.checkThirdParty": true,
 		"Lua.workspace.ignoreSubmodules": false,
 		"Lua.diagnostics.disable": [
 			"lowercase-global",
@@ -16,8 +15,7 @@
 			"duplicate-doc-alias",
 			"duplicate-doc-field"
 		  ],
-		"Lua.runtime.version": "Lua 5.1",
-		"Lua.runtime.plugin": "./anomaly-definitions/plugin.lua"
+		"Lua.runtime.version": "Lua 5.1"
     },
     "files": [
         ".*%.script"

--- a/config.json
+++ b/config.json
@@ -1,11 +1,24 @@
 {
     "settings": {
-            "Lua.diagnostics.disable" : [
-                "lowercase-global"
-            ],
-            "Lua.runtime.version": "Lua 5.1",
-            "Lua.workspace.ignoreSubmodules": false
-        },
+		"files.associations": {
+			"*.script": "lua"
+		},
+		"Lua.workspace.ignoreDir": [ 
+			"lua_help.script"
+		],
+	    "Lua.workspace.checkThirdParty": true,
+		"Lua.workspace.ignoreSubmodules": false,
+		"Lua.diagnostics.disable": [
+			"lowercase-global",
+			"trailing-space",
+			"undefined-global",
+			"duplicate-doc-param",
+			"duplicate-doc-alias",
+			"duplicate-doc-field"
+		  ],
+		"Lua.runtime.version": "Lua 5.1",
+		"Lua.runtime.plugin": "./anomaly-definitions/plugin.lua"
+    },
     "files": [
         ".*%.script"
     ],

--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
 	"settings": {
 		"files.associations": {
-		"*.script": "lua"
+			"*.script": "lua"
 		},
 		"Lua.workspace.ignoreDir": [ 
 			"lua_help.script"

--- a/config.json
+++ b/config.json
@@ -1,24 +1,23 @@
 {
-    "settings": {
-        "files.associations": {
-            "*.script": "lua"
-        },
-        "Lua.workspace.ignoreDir": [ 
-            "lua_help.script"
-        ],
-        "Lua.workspace.ignoreSubmodules": false,
-        "Lua.diagnostics.disable": [
-		    "lowercase-global",
-		    "trailing-space",
-	    	"undefined-global",
-	    	"duplicate-doc-param",
-	    	"duplicate-doc-alias",
-	    	"duplicate-doc-field"
-        ],
-        "Lua.runtime.version": "Lua 5.1"
-    },
-    "files": [
-        ".*%.script"
-    ],
-    "name": "Stalker: Anomaly"
+	"settings": {
+		"files.associations": {
+		"*.script": "lua"
+		},
+		"Lua.workspace.ignoreDir": [ 
+			"lua_help.script"
+		],
+		"Lua.workspace.ignoreSubmodules": false,
+		"Lua.diagnostics.disable": [
+			"lowercase-global",
+			"undefined-global",
+			"duplicate-doc-param",
+			"duplicate-doc-alias",
+			"duplicate-doc-field"
+		],
+		"Lua.runtime.version": "Lua 5.1"
+	},
+	"files": [
+		".*%.script"
+	],
+	"name": "Stalker: Anomaly"
 }

--- a/config.json
+++ b/config.json
@@ -1,21 +1,21 @@
 {
     "settings": {
-		"files.associations": {
-			"*.script": "lua"
-		},
-		"Lua.workspace.ignoreDir": [ 
-			"lua_help.script"
-		],
-		"Lua.workspace.ignoreSubmodules": false,
-		"Lua.diagnostics.disable": [
-			"lowercase-global",
-			"trailing-space",
-			"undefined-global",
-			"duplicate-doc-param",
-			"duplicate-doc-alias",
-			"duplicate-doc-field"
-		  ],
-		"Lua.runtime.version": "Lua 5.1"
+        "files.associations": {
+            "*.script": "lua"
+        },
+        "Lua.workspace.ignoreDir": [ 
+            "lua_help.script"
+        ],
+        "Lua.workspace.ignoreSubmodules": false,
+        "Lua.diagnostics.disable": [
+		    "lowercase-global",
+		    "trailing-space",
+	    	"undefined-global",
+	    	"duplicate-doc-param",
+	    	"duplicate-doc-alias",
+	    	"duplicate-doc-field"
+        ],
+        "Lua.runtime.version": "Lua 5.1"
     },
     "files": [
         ".*%.script"


### PR DESCRIPTION
### Changelog: 

- VS Code associates any `.script` file with Lua (5.1) now
- LLS does not run any diagnostics for `lua_help.script` now, removing 1k+ false positives issued by this file alone, by highjacking the `ignoreDir` rule for a file
- LLS does not check for any `trailing-space`, `undefined-global`, `duplicate-doc-param`, `duplicate-doc-alias` and `duplicate-doc-field`, removing 13k+ false positives